### PR TITLE
es6bindall is no longer a dependency but a devDependency

### DIFF
--- a/dist/react-bootstrap-slider.js
+++ b/dist/react-bootstrap-slider.js
@@ -1,16 +1,16 @@
 (function (global, factory) {
     if (typeof define === "function" && define.amd) {
-        define(["exports", "react", "bootstrap-slider", "es6bindall"], factory);
+        define(["exports", "react", "bootstrap-slider"], factory);
     } else if (typeof exports !== "undefined") {
-        factory(exports, require("react"), require("bootstrap-slider"), require("es6bindall"));
+        factory(exports, require("react"), require("bootstrap-slider"));
     } else {
         var mod = {
             exports: {}
         };
-        factory(mod.exports, global.react, global.bootstrapSlider, global.es6bindall);
+        factory(mod.exports, global.react, global.bootstrapSlider);
         global.reactBootstrapSlider = mod.exports;
     }
-})(this, function (exports, _react, _bootstrapSlider, _es6bindall) {
+})(this, function (exports, _react, _bootstrapSlider) {
     "use strict";
 
     Object.defineProperty(exports, "__esModule", {
@@ -21,8 +21,6 @@
     var _react2 = _interopRequireDefault(_react);
 
     var _bootstrapSlider2 = _interopRequireDefault(_bootstrapSlider);
-
-    var _es6bindall2 = _interopRequireDefault(_es6bindall);
 
     function _interopRequireDefault(obj) {
         return obj && obj.__esModule ? obj : {
@@ -110,7 +108,7 @@
 
             var _this = _possibleConstructorReturn(this, (ReactBootstrapSlider.__proto__ || Object.getPrototypeOf(ReactBootstrapSlider)).call(this, props));
 
-            (0, _es6bindall2.default)(_this, ["updateSliderValues"]);
+            _this.updateSliderValues = _this.updateSliderValues.bind(_this);
             return _this;
         }
 
@@ -121,10 +119,11 @@
                 var sliderAttributes = _extends({}, this.props, {
                     "tooltip": this.props.tooltip || "show"
                 });
+                console.log("sliderAttributes = " + JSON.stringify(sliderAttributes, null, 4));
 
                 this.mySlider = new _bootstrapSlider2.default(this.node, sliderAttributes);
 
-                this.updateSliderValues();
+                //     this.updateSliderValues();
                 if (this.props.change || this.props.handleChange) {
                     var changeEvent = this.props.change || this.props.handleChange;
                     this.mySlider.on("change", function (e) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "bootstrap": "^3.3.7",
     "bootstrap-slider": "^9.4.1",
-    "es6bindall": "0.0.9",
     "jquery": "^3.1.1",
     "react": "^15.4.0",
     "react-dom": "^15.4.0"
@@ -50,6 +49,7 @@
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-2": "^6.18.0",
     "babel-register": "^6.18.0",
+    "es6bindall": "0.0.9",
     "gulp": "^3.9.1",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",

--- a/src/js/react-bootstrap-slider.jsx
+++ b/src/js/react-bootstrap-slider.jsx
@@ -2,7 +2,6 @@
 
 import React, { PropTypes } from "react";
 import Slider from "bootstrap-slider";
-import es6BindAll from "es6bindall";
 // import { isPropNumberOrArray } from "./customproptypes.js";
 
 // Tests to see if prop is a number or an array.  Clunky, but will do for now.
@@ -24,7 +23,7 @@ function isPropNumberOrArray(props, propName, componentName) {
 export class ReactBootstrapSlider extends React.Component {
     constructor(props) {
         super(props);
-        es6BindAll(this, ["updateSliderValues"]);
+        this.updateSliderValues = this.updateSliderValues.bind(this);
     }
 
     componentDidMount() {


### PR DESCRIPTION
Removed the dependency on `es6bindall` for users, but kept it as a devDependency (because it is used in the demo).

The library included `es6bindall` just so that it could do a single bind. This could easily be done with a simple bind command which I added.

By removing the dependence, it allows using react-bootstrap-slider with Require.JS (es6bindall did not play nice with UMD).

Plus, as an added bonus:
- This removes a dependency from users of the library, always a good thing.
- Less code sent to users.
- Runs faster.
- Increases readability (virtually anyone that knows react knows binding in the constructor, not all know this npm module)
- 🎆 