### PR TITLE
componentWillUnmount should destroy gracefully

### DIFF
--- a/src/js/react-bootstrap-slider.jsx
+++ b/src/js/react-bootstrap-slider.jsx
@@ -65,7 +65,7 @@ export class ReactBootstrapSlider extends React.Component {
     }
     
     componentWillUnmount() {
-        this.mySlider.destroy();
+        this.mySlider && this.mySlider.destroy && this.mySlider.destroy();
     }
 
     updateSliderValues() {


### PR DESCRIPTION
If the component is unmounted before fully rendered, it throws an error... 

Resolves the following error:

```
render.js:69 TypeError: Cannot read property 'destroy' of undefined
    at ReactBootstrapSlider.componentWillUnmount (react-bootstrap-slider.js:158)
    at ReactCompositeComponent.js:406
    at measureLifeCyclePerf (ReactCompositeComponent.js:73)
    at ReactCompositeComponentWrapper.unmountComponent (ReactCompositeComponent.js:405)
    at Object.unmountComponent (ReactReconciler.js:76)
    at Object.unmountChildren (ReactChildReconciler.js:144)
    at ReactDOMComponent.unmountChildren (ReactMultiChild.js:369)
    at ReactDOMComponent.unmountComponent (ReactDOMComponent.js:992)
    at Object.unmountComponent (ReactReconciler.js:76)
    at Object.unmountChildren (ReactChildReconciler.js:144)
```